### PR TITLE
Add multi-image support via images_json input

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,30 @@ High-level deployment action that handles both GitOps (ArgoCD) and direct kubect
 
 ## Usage
 
+### Single image deployment
 ```yaml
 - name: Deploy to Kubernetes
   uses: KoalaOps/kustomize-deploy@v1
   with:
     overlay_dir: deploy/overlays/production
     service_name: backend
-    image: myregistry.io/backend:v1.2.3
+    image: myregistry.io/backend
+    tag: v1.2.3
+    environment: production
+```
+
+### Multiple images deployment
+```yaml
+- name: Deploy service with migrator
+  uses: KoalaOps/kustomize-deploy@v1
+  with:
+    overlay_dir: deploy/overlays/production
+    service_name: backend
+    images_json: |
+      [
+        {"name": "myregistry.io/backend", "newTag": "v1.2.3"},
+        {"name": "myregistry.io/backend-migrator", "newTag": "v1.2.3"}
+      ]
     environment: production
 ```
 
@@ -29,7 +46,9 @@ High-level deployment action that handles both GitOps (ArgoCD) and direct kubect
 | `working_directory` | Working directory for operations | ❌ | '.' |
 | `overlay_dir` | Path to kustomize overlay directory | ✅ | - |
 | `service_name` | Service name | ✅ | - |
-| `image` | Full image with tag | ✅ | - |
+| `image` | Image name (without tag) | ❌* | - |
+| `tag` | Image tag | ❌* | - |
+| `images_json` | Multiple images as JSON array (see examples) | ❌* | - |
 | `environment` | Environment name | ✅ | - |
 | `actor` | User deploying | ❌ | `${{ github.actor }}` |
 | `run_id` | Run ID for tracking | ❌ | `${{ github.run_id }}` |
@@ -39,6 +58,8 @@ High-level deployment action that handles both GitOps (ArgoCD) and direct kubect
 | `create_namespace` | Create namespace if it does not exist | ❌ | `true` |
 | `wait_timeout` | Timeout for waiting on deployments (seconds) | ❌ | `120` |
 | `env_patches` | Environment file patches (JSON format) | ❌ | - |
+
+\* Either `images_json` OR both `image` and `tag` must be provided
 
 ## Outputs
 
@@ -87,7 +108,8 @@ app.kubernetes.io/managed-by: argocd
   with:
     overlay_dir: deploy/overlays/${{ inputs.environment }}
     service_name: ${{ inputs.service }}
-    image: ${{ inputs.registry }}/${{ inputs.service }}:${{ inputs.tag }}
+    image: ${{ inputs.registry }}/${{ inputs.service }}
+    tag: ${{ inputs.tag }}
     environment: ${{ inputs.environment }}
 ```
 
@@ -98,7 +120,8 @@ app.kubernetes.io/managed-by: argocd
   with:
     overlay_dir: deploy/overlays/production
     service_name: backend
-    image: myregistry.io/backend:v1.2.3
+    image: myregistry.io/backend
+    tag: v1.2.3
     environment: production
     force_mode: gitops
     commit_message: "Deploy backend v1.2.3 to production"
@@ -111,7 +134,8 @@ app.kubernetes.io/managed-by: argocd
   with:
     overlay_dir: deploy/overlays/staging
     service_name: frontend
-    image: myregistry.io/frontend:latest
+    image: myregistry.io/frontend
+    tag: latest
     environment: staging
     force_mode: kubectl
     wait_timeout: 300
@@ -124,7 +148,8 @@ app.kubernetes.io/managed-by: argocd
   with:
     overlay_dir: deploy/overlays/feature
     service_name: api
-    image: myregistry.io/api:feature-123
+    image: myregistry.io/api
+    tag: feature-123
     environment: feature-123
     create_namespace: true
 ```
@@ -136,7 +161,8 @@ app.kubernetes.io/managed-by: argocd
   with:
     overlay_dir: deploy/overlays/production
     service_name: backend
-    image: myregistry.io/backend:v1.2.3
+    image: myregistry.io/backend
+    tag: v1.2.3
     environment: production
     env_patches: |
       {
@@ -145,6 +171,96 @@ app.kubernetes.io/managed-by: argocd
           "BUILD_ID": "${{ github.run_id }}"
         }
       }
+```
+
+### With multiple images (e.g., app + migrator)
+```yaml
+- name: Deploy service with migrator
+  uses: KoalaOps/kustomize-deploy@v1
+  with:
+    overlay_dir: deploy/overlays/production
+    service_name: backend
+    images_json: |
+      [
+        {"name": "myregistry.io/backend", "newTag": "v1.2.3"},
+        {"name": "myregistry.io/backend-migrator", "newTag": "v1.2.3"}
+      ]
+    environment: production
+```
+
+### Real-world example: Service with database migrations
+```yaml
+- name: Deploy API with DB migrator
+  uses: KoalaOps/kustomize-deploy@v1
+  with:
+    overlay_dir: deploy/overlays/production
+    service_name: api
+    images_json: |
+      [
+        {"name": "europe-docker.pkg.dev/myproject/api", "newTag": "${{ github.sha }}"},
+        {"name": "europe-docker.pkg.dev/myproject/api-migrator", "newTag": "${{ github.sha }}"}
+      ]
+    environment: production
+    env_patches: |
+      {
+        "container.env": {
+          "SENTRY_RELEASE": "${{ github.sha }}",
+          "DEPLOYMENT_ID": "${{ github.run_id }}"
+        }
+      }
+```
+
+## Multiple Images Support
+
+The `images_json` input allows you to deploy services with multiple container images in a single deployment. This is useful for:
+
+- **Database migrations**: Deploy your app alongside a migrator image that runs as an init container or Job
+- **Sidecar containers**: Update multiple images that run together in the same pod
+- **Multi-container services**: Services with multiple containers (e.g., app + proxy, app + logging agent)
+
+### Format
+
+The `images_json` input expects a JSON array:
+
+```json
+[
+  {
+    "name": "registry.io/app",
+    "newTag": "v1.2.3"
+  },
+  {
+    "name": "registry.io/app-migrator",
+    "newTag": "v1.2.3"
+  }
+]
+```
+
+**Required fields:**
+- `name` - Full image name/repository (e.g., `gcr.io/project/image`)
+- `newTag` - Tag to deploy (e.g., `v1.2.3`, `latest`, `sha-abc123`)
+
+**Mutual Exclusivity:**
+Provide either `images_json` OR `image`+`tag`, not both. The action will error if both are provided.
+
+### Common Pattern: Service + Migrator
+
+Many services follow this pattern:
+1. Build both `myapp` and `myapp-migrator` images with the same tag
+2. Deploy both with `images_json`
+3. Migrator runs as Kubernetes Job or init container before the main app starts
+
+```yaml
+- name: Deploy with migrator
+  uses: KoalaOps/kustomize-deploy@v1
+  with:
+    overlay_dir: deploy/overlays/${{ inputs.environment }}
+    service_name: ${{ inputs.service }}
+    images_json: |
+      [
+        {"name": "registry.io/${{ inputs.service }}", "newTag": "${{ inputs.tag }}"},
+        {"name": "registry.io/${{ inputs.service }}-migrator", "newTag": "${{ inputs.tag }}"}
+      ]
+    environment: ${{ inputs.environment }}
 ```
 
 ## Prerequisites
@@ -171,5 +287,6 @@ The action will fail if:
 
 - Always use with cloud-login action for kubectl mode
 - GitOps mode requires repository write permissions
-- Image format must be `registry/repository:tag`
+- For single image: provide `image` (without tag) and `tag` separately
+- For multiple images: use `images_json` with array of `{"name":"...","newTag":"..."}`
 - Supports both Deployment and Rollout resources

--- a/action.yml
+++ b/action.yml
@@ -19,10 +19,13 @@ inputs:
     required: true
   image:
     description: 'Container image name/repository (e.g., ghcr.io/koalaops/myapp)'
-    required: true
+    required: false
   tag:
     description: 'Image tag (e.g., v1.2.3, latest, main-20240915)'
-    required: true
+    required: false
+  images_json:
+    description: 'Multiple images as JSON array [{"name":"registry.io/app","newTag":"v1.2.3"}]. Mutually exclusive with image/tag.'
+    required: false
   environment:
     description: 'Environment name'
     required: true
@@ -80,14 +83,29 @@ runs:
     - name: Validate inputs
       shell: bash
       run: |
+        # Validate overlay directory exists
         if [ ! -d "${{ inputs.working_directory }}/${{ inputs.overlay_dir }}" ]; then
           echo "::error::Overlay directory not found: ${{ inputs.working_directory }}/${{ inputs.overlay_dir }}"
           exit 1
         fi
-        
+
         if [ ! -f "${{ inputs.working_directory }}/${{ inputs.overlay_dir }}/kustomization.yaml" ]; then
           echo "::error::No kustomization.yaml found in overlay directory"
           exit 1
+        fi
+
+        # Validate mutual exclusivity of image inputs
+        if [ -n "${{ inputs.images_json }}" ] && ( [ -n "${{ inputs.image }}" ] || [ -n "${{ inputs.tag }}" ] ); then
+          echo "::error::Provide either images_json OR image+tag, not both."
+          exit 1
+        fi
+
+        # Validate that at least one method is provided
+        if [ -z "${{ inputs.images_json }}" ]; then
+          if [ -z "${{ inputs.image }}" ] || [ -z "${{ inputs.tag }}" ]; then
+            echo "::error::Missing inputs. Provide images_json OR both image and tag."
+            exit 1
+          fi
         fi
     
     - name: Update kustomize manifests
@@ -96,7 +114,8 @@ runs:
         overlay_dir: ${{ inputs.working_directory }}/${{ inputs.overlay_dir }}
         image: ${{ inputs.image }}
         tag: ${{ inputs.tag }}
-        version_label: ${{ inputs.tag }}
+        images_json: ${{ inputs.images_json }}
+        version_label: ${{ inputs.images_json == '' && inputs.tag || '' }}
         annotations: |
           last-deployed-by=${{ inputs.actor || github.actor }}
           deployment-timestamp=${{ github.event.head_commit.timestamp || github.run_id }}
@@ -162,7 +181,7 @@ runs:
       with:
         repository: ${{ inputs.working_directory }}
         commit_message: |
-          ${{ inputs.commit_message || format('Deploy {0} {1} to {2} [skip ci]', inputs.service_name, inputs.image, inputs.environment) }}
+          ${{ inputs.commit_message || format('Deploy {0} to {1} [skip ci]', inputs.service_name, inputs.environment) }}
         file_pattern: '${{ inputs.overlay_dir }}/*'
         commit_user_name: GitHub Actions Bot
         commit_user_email: actions@github.com


### PR DESCRIPTION
Adds support for deploying services with multiple container images. Works with kustomize-edit's multi-image support.

## Changes

- New `images_json` input for multiple images: `[{"name":"registry/app","newTag":"v1.2.3"}]`
- **Mutual exclusivity enforced**: Errors if both `images_json` and `image`+`tag` are provided
- **Conditional version label**: Only sets version label when using single-image mode
- Made `image`/`tag` optional (requires either `images_json` OR both `image`+`tag`)
- Passes `images_json` through to kustomize-edit action
- Fixed all examples to use separate `image` and `tag` parameters
- Added multi-image documentation section

## Use Cases

- Services with database migration containers
- Multi-container pods with coordinated version updates
- Init containers that need version pinning

## Example

```yaml
- uses: KoalaOps/kustomize-deploy@v1
  with:
    overlay_dir: deploy/overlays/production
    service_name: backend
    images_json: |
      [
        {"name": "registry.io/backend", "newTag": "v1.2.3"},
        {"name": "registry.io/backend-migrator", "newTag": "v1.2.3"}
      ]
    environment: production
```

## Dependencies

Requires KoalaOps/kustomize-edit with multi-image support (see KoalaOps/kustomize-edit#3)