### PR TITLE
rebrand: KoalaOps → Skyhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ High-level deployment action that handles both GitOps (ArgoCD) and direct kubect
 ### Single image deployment (recommended - separate image and tag)
 ```yaml
 - name: Deploy to Kubernetes
-  uses: KoalaOps/kustomize-deploy@v1
+  uses: skyhook-io/kustomize-deploy@v1
   with:
     overlay_dir: deploy/overlays/production
     service_name: backend
@@ -27,7 +27,7 @@ High-level deployment action that handles both GitOps (ArgoCD) and direct kubect
 ### Single image (backwards compatible - image:tag format)
 ```yaml
 - name: Deploy to Kubernetes
-  uses: KoalaOps/kustomize-deploy@v1
+  uses: skyhook-io/kustomize-deploy@v1
   with:
     overlay_dir: deploy/overlays/production
     service_name: backend
@@ -38,7 +38,7 @@ High-level deployment action that handles both GitOps (ArgoCD) and direct kubect
 ### Multiple images deployment
 ```yaml
 - name: Deploy service with migrator
-  uses: KoalaOps/kustomize-deploy@v1
+  uses: skyhook-io/kustomize-deploy@v1
   with:
     overlay_dir: deploy/overlays/production
     service_name: backend
@@ -121,7 +121,7 @@ app.kubernetes.io/managed-by: argocd  # or flux
 ### Auto-detect mode (recommended - separate image and tag)
 ```yaml
 - name: Deploy service
-  uses: KoalaOps/kustomize-deploy@v1
+  uses: skyhook-io/kustomize-deploy@v1
   with:
     overlay_dir: deploy/overlays/${{ inputs.environment }}
     service_name: ${{ inputs.service }}
@@ -133,7 +133,7 @@ app.kubernetes.io/managed-by: argocd  # or flux
 ### Auto-detect mode (backwards compatible - image:tag format)
 ```yaml
 - name: Deploy service
-  uses: KoalaOps/kustomize-deploy@v1
+  uses: skyhook-io/kustomize-deploy@v1
   with:
     overlay_dir: deploy/overlays/${{ inputs.environment }}
     service_name: ${{ inputs.service }}
@@ -144,7 +144,7 @@ app.kubernetes.io/managed-by: argocd  # or flux
 ### Force GitOps mode
 ```yaml
 - name: Deploy via GitOps
-  uses: KoalaOps/kustomize-deploy@v1
+  uses: skyhook-io/kustomize-deploy@v1
   with:
     overlay_dir: deploy/overlays/production
     service_name: backend
@@ -158,7 +158,7 @@ app.kubernetes.io/managed-by: argocd  # or flux
 ### Force kubectl mode
 ```yaml
 - name: Direct deployment
-  uses: KoalaOps/kustomize-deploy@v1
+  uses: skyhook-io/kustomize-deploy@v1
   with:
     overlay_dir: deploy/overlays/staging
     service_name: frontend
@@ -172,7 +172,7 @@ app.kubernetes.io/managed-by: argocd  # or flux
 ### With namespace creation
 ```yaml
 - name: Deploy to new namespace
-  uses: KoalaOps/kustomize-deploy@v1
+  uses: skyhook-io/kustomize-deploy@v1
   with:
     overlay_dir: deploy/overlays/feature
     service_name: api
@@ -185,7 +185,7 @@ app.kubernetes.io/managed-by: argocd  # or flux
 ### With environment variable patches
 ```yaml
 - name: Deploy with env patches
-  uses: KoalaOps/kustomize-deploy@v1
+  uses: skyhook-io/kustomize-deploy@v1
   with:
     overlay_dir: deploy/overlays/production
     service_name: backend
@@ -204,7 +204,7 @@ app.kubernetes.io/managed-by: argocd  # or flux
 ### With multiple images (e.g., app + migrator)
 ```yaml
 - name: Deploy service with migrator
-  uses: KoalaOps/kustomize-deploy@v1
+  uses: skyhook-io/kustomize-deploy@v1
   with:
     overlay_dir: deploy/overlays/production
     service_name: backend
@@ -219,7 +219,7 @@ app.kubernetes.io/managed-by: argocd  # or flux
 ### Real-world example: Service with database migrations
 ```yaml
 - name: Deploy API with DB migrator
-  uses: KoalaOps/kustomize-deploy@v1
+  uses: skyhook-io/kustomize-deploy@v1
   with:
     overlay_dir: deploy/overlays/production
     service_name: api
@@ -279,7 +279,7 @@ Many services follow this pattern:
 
 ```yaml
 - name: Deploy with migrator
-  uses: KoalaOps/kustomize-deploy@v1
+  uses: skyhook-io/kustomize-deploy@v1
   with:
     overlay_dir: deploy/overlays/${{ inputs.environment }}
     service_name: ${{ inputs.service }}

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'Kustomize Smart Deploy'
 description: 'Complete kustomize deployment with GitOps detection and metadata extraction'
-author: 'KoalaOps'
+author: 'Skyhook'
 
 branding:
   icon: 'package'
@@ -94,7 +94,7 @@ runs:
         fi
 
     - name: Update kustomize manifests
-      uses: KoalaOps/kustomize-edit@v1
+      uses: skyhook-io/kustomize-edit@v1
       with:
         overlay_dir: ${{ inputs.working_directory }}/${{ inputs.overlay_dir }}
         image: ${{ inputs.image }}
@@ -110,7 +110,7 @@ runs:
     
     - name: Inspect kustomization
       id: inspect
-      uses: KoalaOps/kustomize-inspect@v1
+      uses: skyhook-io/kustomize-inspect@v1
       with:
         overlay_dir: ${{ inputs.working_directory }}/${{ inputs.overlay_dir }}
     
@@ -183,7 +183,7 @@ runs:
     # Kubectl path: direct apply
     - name: Apply with kubectl
       if: ${{ steps.mode.outputs.mode == 'kubectl' }}
-      uses: KoalaOps/kustomize-apply@v1
+      uses: skyhook-io/kustomize-apply@v1
       with:
         overlay_dir: ${{ inputs.working_directory }}/${{ inputs.overlay_dir }}
         namespace: ${{ steps.inspect.outputs.namespace }}


### PR DESCRIPTION
## Summary
Update all references from KoalaOps to Skyhook as part of the rebranding initiative.

## Changes
- Organization: `KoalaOps` → `skyhook-io`
- Author: `KoalaOps` → `Skyhook`
- Product name: `Koala` → `Skyhook` (where applicable)
- All usage examples updated to reference `skyhook-io/*`
- All documentation and URLs updated

## Notes
- This PR should be merged before transferring the repository to the skyhook-io organization
- After transfer, GitHub will automatically redirect old URLs to new ones